### PR TITLE
redirectPath improvements

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -24,9 +24,17 @@ module.exports = function(options) {
   var router = new express.Router();
 
   router.get('/auth/heroku', function(req, res) {
-    //if no redirect set, gracefully redirect to referer
+    //if no redirect set, use passed in query parameters,
+    //otherwise gracefully redirect to referer
     if (!req.session.redirectPath) {
-      req.session.redirectPath = req.headers.referer;
+      var path;
+      var param = req.query.redirectPath;
+      if(param) {
+        path = param;
+      } else {
+        path = req.headers.referer;
+      }
+      req.session.redirectPath = path;
     }
     res.redirect(oauth.getAuthorizeUrl({ response_type: 'code' }));
   });


### PR DESCRIPTION
If there is no `session.redirectPath` then:
- allow `?redirectPath` to be defined and used on `GET /auth/heroku`
- or, set `redirectPath` to original referer url

This is helpful for client side applications that would like to explicitly specify where a user should return after authentication
