### PR TITLE
Excise errant space in default oAuthServerURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function setOptions(options) {
     herokaiOnlyHandler: null,
     herokuAPIHost     : null,
     ignoredRoutes     : [],
-    oAuthServerURL    : 'https: //id.heroku.com',
+    oAuthServerURL    : 'https://id.heroku.com',
     sessionSyncNonce  : null
   };
 


### PR DESCRIPTION
Produces redirects to `https:// id.heroku.com/...`:

![https____20__id_heroku_com_oauth_authorize_response_type_code_client_id_9086387d-f65c-4420-a379-66fe2880c3bb_is_not_available](https://cloud.githubusercontent.com/assets/22723/4056737/eb0704c8-2dbe-11e4-9d7d-3ac2d9a5d219.png)
